### PR TITLE
a bit hacky way to fix style sheet link

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,7 @@ or
 ```
 $ python -m flask run
 ```
+
+## Environment Variables
+KBASE_ENDPOINT: https://kbase.us/services
+ROOT_PREFIX: /applist

--- a/index.py
+++ b/index.py
@@ -14,7 +14,7 @@ app.config['APPLICATION_ROOT'] = '/applist'
 # print('*' * 80)
 # print(app.config['APPLICATION_ROOT'])
 
-_kbase_url = os.environ.get('KBASE_ENDPOINT', 'https://ci.kbase.us/services')
+_kbase_url = os.environ.get('KBASE_ENDPOINT')
 
 if _kbase_url is None:
     raise RuntimeError('config file is missing host address')

--- a/index.py
+++ b/index.py
@@ -8,12 +8,13 @@ app = Flask(__name__)
 
 
 
-app.config['APPLICATION_ROOT'] = os.environ.get('ROOT_PREFIX', '/applist')
+# app.config['APPLICATION_ROOT'] = os.environ.get('ROOT_PREFIX', '/applist')
+app.config['APPLICATION_ROOT'] = '/applist'
 # app.url_map._rules = SubPath(app.config['APPLICATION_ROOT'], app.url_map._rules)
 # print('*' * 80)
 # print(app.config['APPLICATION_ROOT'])
 
-_kbase_url = os.environ.get('KBASE_ENDPOINT')
+_kbase_url = os.environ.get('KBASE_ENDPOINT', 'https://ci.kbase.us/services')
 
 if _kbase_url is None:
     raise RuntimeError('config file is missing host address')
@@ -193,9 +194,9 @@ def get_apps():
     
     return render_template('index.html', options=options, organized_list=organized_list )
 
-@app.route('/apps/')
-def apps():
-   pass
+@app.route('/')
+def index():
+    return 'index'
 
 @app.route('/apps/<app_module>/<app_name>/<tag>', methods=['GET'])
 @app.route('/apps/<app_module>/<app_name>', methods=['GET'])

--- a/index.py
+++ b/index.py
@@ -7,9 +7,7 @@ from collections import defaultdict
 app = Flask(__name__)
 
 
-
-# app.config['APPLICATION_ROOT'] = os.environ.get('ROOT_PREFIX', '/applist')
-app.config['APPLICATION_ROOT'] = '/applist'
+app.config['APPLICATION_ROOT'] = os.environ.get('ROOT_PREFIX', '/applist')
 # app.url_map._rules = SubPath(app.config['APPLICATION_ROOT'], app.url_map._rules)
 # print('*' * 80)
 # print(app.config['APPLICATION_ROOT'])
@@ -17,7 +15,7 @@ app.config['APPLICATION_ROOT'] = '/applist'
 _kbase_url = os.environ.get('KBASE_ENDPOINT')
 
 if _kbase_url is None:
-    raise RuntimeError('config file is missing host address')
+    raise RuntimeError('Missing host address')
 
 _catalog_url = _kbase_url + '/catalog'
 # Narrative Method Store URL requre rpc at the end. 

--- a/static/style.css
+++ b/static/style.css
@@ -248,6 +248,8 @@ div.kbcb-back-link {
 }
 .app-header-icon {
     display: inline-table;
+    width: 93px;
+    height: 93px;
 }
 .app-page-devs {
     font-size: 1em;

--- a/templates/app_page.html
+++ b/templates/app_page.html
@@ -1,16 +1,18 @@
 {% extends "base.html" %}
+{% block content_meta %}<meta name="Kbase App {{ app.name }}" content="{{ app.subtitle }}">{% endblock %}
+{% block title %}<title>{{ app.name }} | KBase App </title>{% endblock %}
+{% block style %}<link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">{% endblock %}
 
 {% block content%}
     <div class="content">
-        <!-- TODO: change href -->
-        <div class="kbcb-back-link"><a href="{{url_for('get_apps')}}"><i class="fa fa-chevron-left"></i> back to the Catalog</a></div>
+        <div class="kbcb-back-link"><a href="{{url_for('index')}}"><i class="fa fa-chevron-left"></i> back to the Catalog</a></div>
         <!-- {{ app }} -->
         <div class="app-header">
             <div class="app-header-icon">
                 {% if app.icon %}
                 <img class="icon-img-l" src="https://kbase.us/services/narrative_method_store/{{ app.icon.url }}" >
                 {% else %}
-                <i class="icon-img fas fa-question-square"></i>       
+                <i class="icon-img fas fa-question-circle fa-5x"></i>       
                 {% endif %} 
             </div>
             <div class="app-header-container">

--- a/templates/base.html
+++ b/templates/base.html
@@ -4,11 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
-    <meta name="Kbase App Catalog" content="KBase apps are analysis tools that you can use in KBase. Apps interoperate seamlessly to enable a range of scientific workflows (see figure below). Some of the apps were written by KBase scientists and developers; others are third-party tools that were integrated into KBase with our Software Developer Kit (SDK). The number of apps available in KBase will increase rapidly as members of the community use our SDK to integrate their analysis tools into the KBase platform.
-The KBase App Catalog lists all of the currently available apps.">
-    <title>KBase App Catalog</title>
-    <!-- TODO: Get rid of this line  -->
-    <link rel="icon" href="data:,">
+    {% block content_meta %}<meta name="Kbase App Catalog" content="KBase apps are analysis tools that you can use in KBase. Apps interoperate seamlessly to enable a range of scientific workflows (see figure below). Some of the apps were written by KBase scientists and developers; others are third-party tools that were integrated into KBase with our Software Developer Kit (SDK). The number of apps available in KBase will increase rapidly as members of the community use our SDK to integrate their analysis tools into the KBase platform.
+The KBase App Catalog lists all of the currently available apps.">{% endblock %}
+    {% block title %}<title>KBase App Catalog</title>{% endblock %}
     <script type="text/javascript" src="https://kbase.us/wp-includes/js/jquery/jquery.js?ver=1.12.4"></script>
     <script type="text/javascript" src="https://kbase.us/wp-includes/js/jquery/jquery-migrate.min.js?ver=1.4.1"></script>
     <script type="text/javascript" src="https://kbase.us/wp-content/themes/kbase-wordpress-theme/js/src/kbaseUtils.js?ver=4.7.3"></script>
@@ -19,7 +17,7 @@ The KBase App Catalog lists all of the currently available apps.">
     <link rel="stylesheet" id="grid-css" href="https://kbase.us/wp-content/themes/kbase-wordpress-theme/css/grid.css?ver=4.7.3" type="text/css" media="all">
     <link rel="stylesheet" id="bootstrap-css" href="https://kbase.us/wp-content/themes/kbase-wordpress-theme/bootstrap/css/bootstrap.min.css?ver=4.7.3" type="text/css" media="all">
     <link rel="stylesheet" id="bootstrap-theme-css" href="https://kbase.us/wp-content/themes/kbase-wordpress-theme/bootstrap/css/bootstrap-theme.css?ver=4.7.3" type="text/css" media="all">    
-    <link rel="stylesheet" href="static/style.css">
+    {% block style %}<link rel="stylesheet" href="static/style.css">{% endblock %}
 </head>
 
 <body>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+
 {% block content%}
     <nav class="sticky">
         <div id="app-catalog-header">
@@ -38,13 +39,13 @@
                     <div class="organized-by sticky">{{ item }}</div>
                 {% if app_list %}
                 {% for app in app_list %}
-                    <a href="{{url_for('apps')}}{{ app.id }}/release">
+                    <a href="apps/{{ app.id }}/release">
                         <div class="app-card kbcb-hover">
                             <div class="app-card-header" module="{{ item }}" name="{{ app.name }}" id="{{ app.id}}">
                                 {% if app.icon %}
                                 <img class="icon-img" src="https://kbase.us/services/narrative_method_store/{{ app.icon.url }}" >
                                 {% else %}
-                                <i class="icon-img fas fa-question-square"></i>       
+                                <i class="icon-img fas fa-question-circle fa-2x"></i>       
                                 {% endif %} 
                                 <p class="app-title"> {{ app.name }} </p>
                             </div>


### PR DESCRIPTION
a bit hacky way to fix style sheet link, but this should work. Added app page title and subtitle while I'm at it.  index.html line 42 had to be hardcoded since url_for by flask doesn't seem to get rid of leading hash unelss more library get imported and add some ugly things. url_for index added. Hopefully this works.